### PR TITLE
Stili diversi per il testo delle domande e regolazione interlinea

### DIFF
--- a/script.js
+++ b/script.js
@@ -161,7 +161,6 @@ function nextQuestion() {
   }
 }
 
-// Funzione per mostrare una domanda specifica
 function showQuestion(questionIndex) {
   const currentQuestion = questions[questionIndex];
 
@@ -169,7 +168,25 @@ function showQuestion(questionIndex) {
   currentQuestionElement.textContent = questionIndex + 1;
 
   // Mostra la domanda
-  questionTitle.innerHTML = currentQuestion.question;
+  const questionText = currentQuestion.question;
+
+  if (questionText.length > 60) {
+    // Trova l'ultimo spazio prima del carattere 60 per non spezzare le parole
+    const breakpoint = questionText.lastIndexOf(" ", 60);
+    const firstPart = questionText.slice(0, breakpoint).trim();
+    const secondPart = questionText.slice(breakpoint).trim();
+
+    // Aggiunge le due parti con stili diversi
+    questionTitle.innerHTML = `
+      <span class="text-normal">${firstPart}</span><br>
+      <span class="text-highlight">${secondPart}</span>
+    `;
+  } else {
+    // Testo normale sotto i 60 caratteri
+    questionTitle.innerHTML = `
+      <span class="text-normal">${questionText}</span>
+    `;
+  }
 
   // Mescola le risposte
   let answers = [...currentQuestion.incorrect_answers, currentQuestion.correct_answer];

--- a/style.css
+++ b/style.css
@@ -123,12 +123,29 @@ h1 span {
 /* Contenitore della domanda */
 .question-container {
     text-align: center;
-    margin-top: 240px;
+    margin-top: 200px;
 }
 
-.question-container h1 {
-    margin-top: 10vh;
+.question-title {
+  line-height: 1.0;
 }
+
+.text-normal {
+  font-family: "Outfit", sans-serif;
+  font-weight: 300;
+  margin-top: 0;
+  font-size: 40px;
+  display: inline;
+}
+
+.text-highlight {
+  font-family: "Outfit", sans-serif;
+  font-weight: 700;
+  margin-top: 0;
+  font-size: 40px;
+  display: inline;
+}
+
 
 /* Bottoni delle risposte */
 .answer-button {
@@ -177,7 +194,7 @@ h1 span {
 }
 
 .question-footer {
-    margin-top: 25vh;
+    margin-top: 150px;
 }
 
 /* Timer circolare */


### PR DESCRIPTION
**Implementata la separazione del testo delle domande in due parti con stili distinti:**

- Prima parte con font-family: "Outfit", sans-serif; font-weight: 300.
- Seconda parte con font-family: "Outfit", sans-serif; font-weight: 700.
- Migliorata l'interlinea tra le righe per una migliore leggibilità.